### PR TITLE
Unsubscribe all events on '.more' when destroyed.

### DIFF
--- a/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
+++ b/projects/ids-enterprise-ng/src/lib/toolbar/soho-toolbar.component.ts
@@ -466,6 +466,7 @@ export class SohoToolbarComponent implements AfterViewChecked, AfterViewInit, On
     // call outside the angular zone so change detection isn't triggered by the soho component.
     this.ngZone.runOutsideAngular(() => {
       if (this.jQueryElement) {
+        this.jQueryElement.find('.more').off();
         this.jQueryElement.off();
       }
       if (this.toolbar) {


### PR DESCRIPTION
Events on '.more' button is not unsubscribed when destroyed causing memory leaks in soho-toolbar component (enterprise-ng).

Details:
Dynamically creating and removing <soho-toolbar/> will cause memory leaks because the events for the more button (mouseover event) was not unsubscribed when the component is destroyed.

Jira Ticket:
https://github.com/infor-design/enterprise-ng/issues/560

**Steps necessary to review your pull request (required)**:
Dynamically create a '<soho-toolbar/>'
Remove the '<soho-toolbar/>'
Repeat several times
On developer tools, check Heap Snapshot, all instances of soho-toolbar is still retained.
